### PR TITLE
adding empty line after badge so table renders properly

### DIFF
--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -204,6 +204,7 @@ namespace CodeCoverageSummary
             if (!string.IsNullOrWhiteSpace(badgeUrl))
             {
                 markdownOutput.AppendLine($"![Code Coverage]({badgeUrl})");
+                markdownOutput.AppendLine("");
             }
 
             markdownOutput.AppendLine("Package | Line Rate | Branch Rate | Complexity")


### PR DESCRIPTION
Appending an empty line after the badge to render the markdown table properly.

Before:
![Code Coverage](https://img.shields.io/badge/Code%20Coverage-100%25-success?style=flat)
Package | Line Rate | Branch Rate | Complexity
-------- | --------- | ----------- | ----------
PrimeService | 100% | 100% | 6
**Summary** | **100%** (12 / 12) | **100%** (6 / 6) | 6

After:
![Code Coverage](https://img.shields.io/badge/Code%20Coverage-100%25-success?style=flat)

Package | Line Rate | Branch Rate | Complexity
-------- | --------- | ----------- | ----------
PrimeService | 100% | 100% | 6
**Summary** | **100%** (12 / 12) | **100%** (6 / 6) | 6

<!-- Sticky Pull Request Comment -->