### PR TITLE
Handle optional complexity attribute

### DIFF
--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -141,7 +141,7 @@ namespace CodeCoverageSummary
                         Name = item.Attribute("name").Value,
                         LineRate = double.Parse(item.Attribute("line-rate").Value),
                         BranchRate = double.Parse(item.Attribute("branch-rate").Value),
-                        Complexity = int.Parse(item.Attribute("complexity").Value)
+                        Complexity = int.Parse(item.Attribute("complexity")?.Value ?? "0")
                     };
                     summary.Packages.Add(packageCoverage);
                     summary.Complexity += packageCoverage.Complexity;


### PR DESCRIPTION
In the eventuality of the complexity attribute to be missing, provide a default "0" value in its place.