### PR TITLE
Bump docker image to v1.0.3 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: 'console'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/irongut/codecoveragesummary:v1.0.2'
+  image: 'docker://ghcr.io/irongut/codecoveragesummary:v1.0.3'
   args:
     - ${{ inputs.filename }}
     - '--badge'


### PR DESCRIPTION
I guess you will either have to recreate the v1.0.3 tag and the release manually from the merged commit, or go forward with a v1.0.4 release but you will need to bump the version in action.yml again.