### PR TITLE
Issue36 include class coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Hide Branch Rate values in the output - `true` or `false` (default).
 
 Hide Complexity values in the output - `true` or `false` (default).
 
+### `show_class_names`
+
+Show individual class detail in the output - `true` / `false` (default)
 
 ### `indicators`
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action.'
     required: false
     default: '50 75'
+  show_class_names:
+    description: 'Show individual class detail in the output - true / false (default)'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/irongut/codecoveragesummary:v1.2.0'
@@ -62,3 +66,5 @@ runs:
     - ${{ inputs.output }}
     - '--thresholds'
     - ${{ inputs.thresholds }}
+    - '--showclassnames'
+    - ${{ inputs.show_class_names }}

--- a/src/CodeCoverageSummary/CodeSummary.cs
+++ b/src/CodeCoverageSummary/CodeSummary.cs
@@ -6,6 +6,8 @@ namespace CodeCoverageSummary
     {
         public string Name { get; set; }
 
+        public string FileName { get; set; }
+
         public double LineRate { get; set; }
 
         public double BranchRate { get; set; }

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -34,7 +34,7 @@ namespace CodeCoverageSummary
 
         [Option(longName: "showclassnames", Required = false, HelpText = "Show individual class detail in the output - true or false.", Default = "true")]
         public string ShowClassNamesString { get; set; }
-        public bool ShowClassNames => ShowClassNamesString.Equals("false", StringComparison.OrdinalIgnoreCase);
+        public bool ShowClassNames => ShowClassNamesString.Equals("true", StringComparison.OrdinalIgnoreCase);
 
         [Option(longName: "indicators", Required = false, HelpText = "Include health indicators in the output - true or false.", Default = "true")]
         public string IndicatorsString { get; set; }

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -32,7 +32,7 @@ namespace CodeCoverageSummary
 
         public bool HideComplexity => HideComplexityString.Equals("true", StringComparison.OrdinalIgnoreCase);
 
-        [Option(longName: "showclassnames", Required = false, HelpText = "Show individual class detail in the output - true or false.", Default = "true")]
+        [Option(longName: "showclassnames", Required = false, HelpText = "Show individual class detail in the output - true or false.", Default = "false")]
         public string ShowClassNamesString { get; set; }
         public bool ShowClassNames => ShowClassNamesString.Equals("true", StringComparison.OrdinalIgnoreCase);
 

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -32,6 +32,10 @@ namespace CodeCoverageSummary
 
         public bool HideComplexity => HideComplexityString.Equals("true", StringComparison.OrdinalIgnoreCase);
 
+        [Option(longName: "showclassnames", Required = false, HelpText = "Show individual class detail in the output - true or false.", Default = "true")]
+        public string ShowClassNamesString { get; set; }
+        public bool ShowClassNames => ShowClassNamesString.Equals("false", StringComparison.OrdinalIgnoreCase);
+
         [Option(longName: "indicators", Required = false, HelpText = "Include health indicators in the output - true or false.", Default = "true")]
         public string IndicatorsString { get; set; }
 

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -209,7 +209,7 @@ namespace CodeCoverageSummary
                 var packages = from item in coverage.Descendants("package")
                            select item;
 
-                if (!showClassNames)
+                if (showClassNames && packages.Any())
                     packages = from item in coverage.Descendants("package").Descendants("class")
                                select item;
 

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -209,12 +209,15 @@ namespace CodeCoverageSummary
                 var packages = from item in coverage.Descendants("package")
                            select item;
 
+                if (!packages.Any())
+                    throw new Exception("No package data found");
+
                 if (showClassNames && packages.Any())
                     packages = from item in coverage.Descendants("package").Descendants("class")
                                select item;
 
                 if (!packages.Any())
-                    throw new Exception("No package data found");
+                    throw new Exception("No class data found");
 
                 int i = 1;
                 foreach (var item in packages)

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -47,7 +47,7 @@ namespace CodeCoverageSummary
                                          foreach (var file in matchingFiles)
                                          {
                                              Console.WriteLine($"Coverage File: {file}");
-                                             summary = ParseTestResults(file, summary);
+                                             summary = ParseTestResults(file, summary, o.ShowClassNames);
                                          }
 
                                          if (summary == null)
@@ -138,7 +138,7 @@ namespace CodeCoverageSummary
                                  _ => -1); // invalid arguments
         }
 
-        private static CodeSummary ParseTestResults(string filename, CodeSummary summary)
+        private static CodeSummary ParseTestResults(string filename, CodeSummary summary, bool showClassNames)
         {
             if (summary == null)
                 return null;
@@ -207,6 +207,10 @@ namespace CodeCoverageSummary
 
                 // test coverage for individual packages
                 var packages = from item in coverage.Descendants("package")
+                           select item;
+
+                if (!showClassNames)
+                    packages = from item in coverage.Descendants("package").Descendants("class")
                                select item;
 
                 if (!packages.Any())

--- a/src/CodeCoverageSummary/Properties/launchSettings.json
+++ b/src/CodeCoverageSummary/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CodeCoverageSummary": {
       "commandName": "Project",
-      "commandLineArgs": "--files coverage.*.xml --format=md --badge true --thresholds=\"85 90\" --fail true --showclassnames true"
+      "commandLineArgs": "--files **/coverage.*.xml --format=text --badge true --thresholds=\"85 90\" --fail true"
     },
     "Docker": {
       "commandName": "Docker",

--- a/src/CodeCoverageSummary/Properties/launchSettings.json
+++ b/src/CodeCoverageSummary/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CodeCoverageSummary": {
       "commandName": "Project",
-      "commandLineArgs": "--files **/coverage.*.xml --format=text --badge true --thresholds=\"85 90\" --fail true"
+      "commandLineArgs": "--files coverage.*.xml --format=md --badge true --thresholds=\"85 90\" --fail true --showclassnames true"
     },
     "Docker": {
       "commandName": "Docker",


### PR DESCRIPTION
Added `showclassnames` parameter to add class names and class code coverage results to output. It defaults to false.

Updated README.md to reflect changes. 