### PR TITLE
fixes glob pattern/multi file line and branch rate calculation

### DIFF
--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -53,8 +53,8 @@ namespace CodeCoverageSummary
                                          if (summary == null)
                                              return -2; // error
 
-                                         summary.LineRate /= matchingFiles.Count();
-                                         summary.BranchRate /= matchingFiles.Count();
+                                         summary.LineRate = summary.LinesCovered / summary.LinesValid;
+                                         summary.BranchRate = summary.BranchesCovered / summary.BranchesValid;
 
                                          if (summary.Packages.Count == 0)
                                          {


### PR DESCRIPTION
This will change will calculate the total coverage rate using the formula

```math
\frac{ \sum_{i=1}^{n} linesCovered_i } { \sum_{i=1}^{n} linesValid_i }
```

Calculating the average of two percentages is not valid as that gives the same weight to a 100% coverage rate of 10 lines as a 20% coverage rate of 1000 lines.

Since `ParseTestResults` is already getting the total lines covered and total lines valid this only needs to update the final coverage rate values. I considered updating how `ParseTestResults` is performing the calculations but ultimately decided this was the most direct approach and impact the least number of flows through the code.
