### PR TITLE
Add configuration to build container image for ARM64

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -86,8 +86,17 @@ jobs:
         with:
           cosign-release: 'v1.9.0'
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
+        with:
+          platforms: arm64
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -106,6 +115,9 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         with:
+          platforms: |
+            linux/amd64
+            linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -117,4 +129,4 @@ jobs:
       - name: Sign the Docker image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --recursive {}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
relates to #60.

This pull request add build configuration for container image for ARM64 architecture.
This is achieved by creating multi-platform image by using QEMU, docker/setup-buildx-action and docker/build-push-action.

The multi-platform image enables users to automatically select image suitable for their platform by specifying same container image tag.