### PR TITLE
Add continue_on_empty_test input

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ See [`thresholds`](#thresholds) to change these values.
 
 Fail the workflow if the overall Line Rate is below lower threshold - `true` or `false` (default). The default lower threshold is 50%, see [`thresholds`](#thresholds).
 
+### `continue_on_empty_test`
+
+When jest is run an no tests are detected, the coverage report generated has no packages. Default behaviour is to throw an error when this occurs. This flag can be set to `true` to continue if no tests are detected in the coverage reports
 
 ### `format`
 
@@ -109,13 +112,13 @@ Minimum allowed line rate is 50%
 ### Markdown Example
 
 > ![Code Coverage](https://img.shields.io/badge/Code%20Coverage-83%25-success?style=flat)
-> 
+>
 > Package | Line Rate | Branch Rate | Complexity | Health
 > -------- | --------- | ----------- | ---------- | ------
 > Company.Example | 83% | 69% | 671 | ✔
 > Company.Example.Library | 27% | 100% | 11 | ❌
 > **Summary** | **83%** (1212 / 1460) | **69%** (262 / 378) | 682 | ✔
-> 
+>
 > _Minimum allowed line rate is `50%`_
 
 
@@ -168,6 +171,7 @@ jobs:
         filename: coverage/**/coverage.cobertura.xml
         badge: true
         fail_below_min: true
+        continue_on_empty_test: false
         format: markdown
         hide_branch_rate: false
         hide_complexity: true

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Fail if overall Line Rate below lower threshold - true / false (default).'
     required: false
     default: 'false'
+  continue_on_empty_test:
+    description: 'Continue if no packages are detected on input coverage reports'
+    required: false
+    default: 'false'
   format:
     description: 'Output Format - markdown or text (default).'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,8 @@ runs:
     - ${{ inputs.badge }}
     - '--fail'
     - ${{ inputs.fail_below_min }}
+    - '--continue_on_empty_test'
+    - ${{ inputs.continue_on_empty_test }}
     - '--format'
     - ${{ inputs.format }}
     - '--hidebranch'

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -17,6 +17,9 @@ namespace CodeCoverageSummary
         [Option(longName: "fail", Required = false, HelpText = "Fail if overall Line Rate below lower threshold - true or false.", Default = "false")]
         public string FailString { get; set; }
 
+        [Option(longName: "continue_on_empty_test", Required = false, HelpText = "COntinue and do not throw error if empty coverage test encountered", Default = "false")]
+        public string continue_on_empty_testString { get; set; }
+
         public bool FailBelowThreshold => FailString.Equals("true", StringComparison.OrdinalIgnoreCase);
 
         [Option(longName: "format", Required = false, HelpText = "Output Format - markdown or text.", Default = "text")]

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -208,7 +208,24 @@ namespace CodeCoverageSummary
                                select item;
 
                 if (!packages.Any())
-                    throw new Exception("No package data found");
+                {
+                    if (!continue_on_empty_test)
+                        throw new Exception("No package data found");
+
+
+                    CodeCoverage packageCoverage = new()
+                    {
+                        Name = $"{Path.GetFileNameWithoutExtension(filename)}",
+                        LineRate = 0,
+                        BranchRate = 0,
+                        Complexity = 0
+                    };
+                    summary.Packages.Add(packageCoverage);
+                    summary.Complexity += packageCoverage.Complexity;
+
+                    return summary;
+                }
+
 
                 int i = 1;
                 foreach (var item in packages)
@@ -352,7 +369,7 @@ namespace CodeCoverageSummary
             {
                 markdownOutput.Append($"{package.Name} | {package.LineRate * 100:N0}%")
                               .Append(hideBranchRate ? string.Empty : $" | {package.BranchRate * 100:N0}%")
-                              .Append(hideComplexity ? string.Empty : (package.Complexity % 1 == 0) ? $" | {package.Complexity}" : $" | {package.Complexity:N4}" )
+                              .Append(hideComplexity ? string.Empty : (package.Complexity % 1 == 0) ? $" | {package.Complexity}" : $" | {package.Complexity:N4}")
                               .AppendLine(indicators ? $" | {GenerateHealthIndicator(package.LineRate)}" : string.Empty);
             }
 


### PR DESCRIPTION
We run an nx monorepo which automatically generates jest config files for each of our applications and libraries. Sometimes a library will not have any tests during early stages of working on it but the testing config will already be setup which will result in a coverage.xml file with no packages in it. We'd like to use this github action for coverage test report checks without having to manually disable and enable our testing scripts for individual packages without tests yet.

I've attempted to add a flag continue_on_empty_test that just generates an zero value coverage summary for a coverage report file instead of throwing an error. Defaulted to false to maintain current behaviour unless you opt-in.

Would be good to get your thoughts on this proposal, Cheers.