### PR TITLE
Add GITHUB_OUTPUT support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: 'true'
   output:
-    description: 'Output Type - console (default), file or both.'
+    description: 'Output Type - console (default), file or both. Also supports github output.'
     required: false
     default: 'console'
   thresholds:

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -37,7 +37,7 @@ namespace CodeCoverageSummary
 
         public bool Indicators => IndicatorsString.Equals("true", StringComparison.OrdinalIgnoreCase);
 
-        [Option(longName: "output", Required = false, HelpText = "Output Type - console, file or both.", Default = "console")]
+        [Option(longName: "output", Required = false, HelpText = "Output Type - console, file or both. Also supports github output", Default = "console")]
         public string Output { get; set; }
 
         [Option(longName: "thresholds", Required = false, HelpText = "Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action.", Default = "50 75")]

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -114,6 +114,24 @@ namespace CodeCoverageSummary
                                                  Console.WriteLine(output);
                                                  File.WriteAllText($"code-coverage-results.{fileExt}", output);
                                              }
+                                             else if (o.Output.Equals("github", StringComparison.OrdinalIgnoreCase))
+                                             {
+                                                 var envFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
+                                                if (string.IsNullOrWhiteSpace(envFile))
+                                                {
+                                                    Console.WriteLine("Error: GITHUB_OUTPUT environment variable not set.");
+                                                    return -2; // error
+                                                }
+
+                                                using var writer = new StreamWriter(envFile, append: true, Encoding.UTF8);
+
+                                                writer.WriteLine("badge=" + badgeUrl);
+                                                writer.WriteLine("line_rate=" + (summary.LineRate * 100).ToString("0.00"));
+                                                writer.WriteLine("branch_rate=" + (summary.BranchRate * 100).ToString("0.00"));
+                                                writer.WriteLine("complexity=" + summary.Complexity.ToString("0.00"));
+                                                writer.WriteLine("health=" + GenerateHealthIndicator(summary.LineRate));
+                                                writer.Flush();
+                                             }
                                              else
                                              {
                                                  Console.WriteLine("Error: Unknown output type.");


### PR DESCRIPTION
Fixes #232.

Adds support for a new output: `github`, that emits the following outputs for use in GitHub actions:
- badge: the URL for the badge
- line_rate: The line rate in percent (two decimal places)
- branch_rate: The branch rate in percent (two decimal places)
- complexity: The complexity (two decimal places)
- health: a health indicator emoji

Let me know what you think or what should be improved!