### PR TITLE
Automatically publish GitHub step summary

### DIFF
--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -99,6 +99,12 @@ namespace CodeCoverageSummary
                                              }
 
                                              // output
+                                             var githubSummaryFile = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+                                             if (!string.IsNullOrEmpty(githubSummaryFile))
+                                             {
+                                                 File.AppendAllText(githubSummaryFile, output);
+                                             }
+
                                              if (o.Output.Equals("console", StringComparison.OrdinalIgnoreCase))
                                              {
                                                  Console.WriteLine();


### PR DESCRIPTION
Here documentation explains how to [add a job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).

Closes #270 