### PR TITLE
Add title option to Code Coverage Summary output

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -115,4 +115,4 @@ jobs:
       - name: Sign the Docker image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,10 +84,10 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
         with:
-          cosign-release: 'v3.8.0'
+          cosign-release: 'v2.4.2'
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -82,12 +82,10 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
-        with:
-          cosign-release: 'v2.4.2'
+        uses: sigstore/cosign-installer@v3.8.0
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v3.8.0'
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ jobs:
         indicators: true
         output: both
         thresholds: '60 80'
+        title: "Code Coverage Summary"
 
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2

--- a/action.yml
+++ b/action.yml
@@ -1,64 +1,70 @@
-name: 'Code Coverage Summary'
-author: 'Irongut <murray.dave@outlook.com>'
-description: 'A GitHub Action that reads Cobertura format code coverage files and outputs a text or markdown summary.'
+name: "Code Coverage Summary"
+author: "Irongut <murray.dave@outlook.com>"
+description: "A GitHub Action that reads Cobertura format code coverage files and outputs a text or markdown summary."
 branding:
   icon: book-open
   color: purple
 inputs:
   filename:
-    description: 'A comma separated list of code coverage files to analyse. Also supports using glob patterns to match multiple files.'
+    description: "A comma separated list of code coverage files to analyse. Also supports using glob patterns to match multiple files."
     required: true
   badge:
-    description: 'Include a Line Rate coverage badge in the output using shields.io - true / false (default).'
+    description: "Include a Line Rate coverage badge in the output using shields.io - true / false (default)."
     required: false
-    default: 'false'
+    default: "false"
   fail_below_min:
-    description: 'Fail if overall Line Rate below lower threshold - true / false (default).'
+    description: "Fail if overall Line Rate below lower threshold - true / false (default)."
     required: false
-    default: 'false'
+    default: "false"
   format:
-    description: 'Output Format - markdown or text (default).'
+    description: "Output Format - markdown or text (default)."
     required: false
-    default: 'text'
+    default: "text"
   hide_branch_rate:
-    description: 'Hide Branch Rate values in the output - true / false (default).'
+    description: "Hide Branch Rate values in the output - true / false (default)."
     required: false
-    default: 'false'
+    default: "false"
   hide_complexity:
-    description: 'Hide Complexity values in the output - true / false (default).'
+    description: "Hide Complexity values in the output - true / false (default)."
     required: false
-    default: 'false'
+    default: "false"
   indicators:
-    description: 'Include health indicators in the output - true (default) / false.'
+    description: "Include health indicators in the output - true (default) / false."
     required: false
-    default: 'true'
+    default: "true"
   output:
-    description: 'Output Type - console (default), file or both.'
+    description: "Output Type - console (default), file or both."
     required: false
-    default: 'console'
+    default: "console"
   thresholds:
-    description: 'Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action.'
+    description: "Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action."
     required: false
-    default: '50 75'
+    default: "50 75"
+  title:
+    description: "Title to use in the output."
+    required: false
+    default: "Code Coverage Summary"
 runs:
-  using: 'docker'
-  image: 'docker://ghcr.io/irongut/codecoveragesummary:v1.3.0'
+  using: "docker"
+  image: "docker://ghcr.io/irongut/codecoveragesummary:v1.3.0"
   args:
-    - '--files'
+    - "--files"
     - ${{ inputs.filename }}
-    - '--badge'
+    - "--badge"
     - ${{ inputs.badge }}
-    - '--fail'
+    - "--fail"
     - ${{ inputs.fail_below_min }}
-    - '--format'
+    - "--format"
     - ${{ inputs.format }}
-    - '--hidebranch'
+    - "--hidebranch"
     - ${{ inputs.hide_branch_rate }}
-    - '--hidecomplexity'
+    - "--hidecomplexity"
     - ${{ inputs.hide_complexity }}
-    - '--indicators'
+    - "--indicators"
     - ${{ inputs.indicators }}
-    - '--output'
+    - "--output"
     - ${{ inputs.output }}
-    - '--thresholds'
+    - "--thresholds"
     - ${{ inputs.thresholds }}
+    - "--title"
+    - ${{ inputs.title }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "Code Coverage Summary"
-author: "Irongut <murray.dave@outlook.com>"
+name: "Code Coverage Summary with Title"
+author: "syed-farazahmed <faraz313ahmed@emumba.com>"
 description: "A GitHub Action that reads Cobertura format code coverage files and outputs a text or markdown summary."
 branding:
   icon: book-open

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     default: "Code Coverage Summary"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/irongut/codecoveragesummary:v1.3.0"
+  image: "docker://ghcr.io/syed-farazahmed/codecoveragesummary:v1.0.1"
   args:
     - "--files"
     - ${{ inputs.filename }}

--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -42,5 +42,8 @@ namespace CodeCoverageSummary
 
         [Option(longName: "thresholds", Required = false, HelpText = "Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action.", Default = "50 75")]
         public string Thresholds { get; set; }
+
+        [Option(longName: "title", Required = false, HelpText = "Title for the output.", Default = "Code Coverage Summary")]
+        public string Title { get; set; }
     }
 }

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -299,7 +299,7 @@ namespace CodeCoverageSummary
             }
             else
             {
-                return "✔";
+                return "✅";
             }
         }
 

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -303,7 +303,7 @@ namespace CodeCoverageSummary
             }
         }
 
-        private static string GenerateTextOutput(CodeSummary summary, string badgeUrl, bool indicators, bool hideBranchRate, bool hideComplexity)
+        private static string GenerateTextOutput(CodeSummary summary, string badgeUrl, bool indicators, bool hideBranchRate, bool hideComplexity, string title)
         {
             StringBuilder textOutput = new();
             if (!string.IsNullOrWhiteSpace(title))
@@ -335,7 +335,7 @@ namespace CodeCoverageSummary
             return textOutput.ToString();
         }
 
-        private static string GenerateMarkdownOutput(CodeSummary summary, string badgeUrl, bool indicators, bool hideBranchRate, bool hideComplexity)
+        private static string GenerateMarkdownOutput(CodeSummary summary, string badgeUrl, bool indicators, bool hideBranchRate, bool hideComplexity, string title)
         {
             StringBuilder markdownOutput = new();
 
@@ -344,7 +344,7 @@ namespace CodeCoverageSummary
                 markdownOutput.AppendLine($"# {title}")
                             .AppendLine();
             }
-            
+
             if (!string.IsNullOrWhiteSpace(badgeUrl))
             {
                 markdownOutput.AppendLine($"![Code Coverage]({badgeUrl})")

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -81,14 +81,14 @@ namespace CodeCoverageSummary
                                              if (o.Format.Equals("text", StringComparison.OrdinalIgnoreCase))
                                              {
                                                  fileExt = "txt";
-                                                 output = GenerateTextOutput(summary, badgeUrl, o.Indicators, hideBranchRate, o.HideComplexity);
+                                                 output = GenerateTextOutput(summary, badgeUrl, o.Indicators, hideBranchRate, o.HideComplexity,  o.Title);
                                                  if (o.FailBelowThreshold)
                                                      output += $"Minimum allowed line rate is {lowerThreshold * 100:N0}%{Environment.NewLine}";
                                              }
                                              else if (o.Format.Equals("md", StringComparison.OrdinalIgnoreCase) || o.Format.Equals("markdown", StringComparison.OrdinalIgnoreCase))
                                              {
                                                  fileExt = "md";
-                                                 output = GenerateMarkdownOutput(summary, badgeUrl, o.Indicators, hideBranchRate, o.HideComplexity);
+                                                 output = GenerateMarkdownOutput(summary, badgeUrl, o.Indicators, hideBranchRate, o.HideComplexity, o.Title);
                                                  if (o.FailBelowThreshold)
                                                      output += $"{Environment.NewLine}_Minimum allowed line rate is `{lowerThreshold * 100:N0}%`_{Environment.NewLine}";
                                              }
@@ -306,6 +306,12 @@ namespace CodeCoverageSummary
         private static string GenerateTextOutput(CodeSummary summary, string badgeUrl, bool indicators, bool hideBranchRate, bool hideComplexity)
         {
             StringBuilder textOutput = new();
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                textOutput.AppendLine(title)
+                        .AppendLine(new string('=', title.Length))
+                        .AppendLine();
+            }
 
             if (!string.IsNullOrWhiteSpace(badgeUrl))
             {
@@ -333,6 +339,12 @@ namespace CodeCoverageSummary
         {
             StringBuilder markdownOutput = new();
 
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                markdownOutput.AppendLine($"# {title}")
+                            .AppendLine();
+            }
+            
             if (!string.IsNullOrWhiteSpace(badgeUrl))
             {
                 markdownOutput.AppendLine($"![Code Coverage]({badgeUrl})")


### PR DESCRIPTION
This pull request includes several changes to add a "title" field to the code coverage summary output and to standardize the use of double quotes in the `action.yml` file.

### Adding "title" field to code coverage summary:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177): Added a "title" field to the job configuration to allow setting a custom title for the code coverage summary.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R70): Introduced a new input parameter `title` to specify a title for the output, with a default value of "Code Coverage Summary".
* [`src/CodeCoverageSummary/CommandLineOptions.cs`](diffhunk://#diff-016df26808bd766df64eb5da58d11804b6236e2fe7875516c9e544198d115f20R45-R47): Added a new option `Title` to the `CommandLineOptions` class to accept a title for the output.
* [`src/CodeCoverageSummary/Program.cs`](diffhunk://#diff-98ae33ad1a24fc43478e1538d05d7557426c15036d0ff8ad6e0bf227d08fe18eL84-R91): Updated the `GenerateTextOutput` and `GenerateMarkdownOutput` methods to include the title in the output if provided. [[1]](diffhunk://#diff-98ae33ad1a24fc43478e1538d05d7557426c15036d0ff8ad6e0bf227d08fe18eL84-R91) [[2]](diffhunk://#diff-98ae33ad1a24fc43478e1538d05d7557426c15036d0ff8ad6e0bf227d08fe18eR309-R314) [[3]](diffhunk://#diff-98ae33ad1a24fc43478e1538d05d7557426c15036d0ff8ad6e0bf227d08fe18eR342-R347)

### Standardizing quotes in `action.yml`:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R70): Replaced single quotes with double quotes for consistency across the file.