### PR TITLE
Fixes #372 Add --verbosity diagnostic flag option 

### DIFF
--- a/src/CodeCoverageSummary/CommandLineOptions.cs
+++ b/src/CodeCoverageSummary/CommandLineOptions.cs
@@ -42,5 +42,8 @@ namespace CodeCoverageSummary
 
         [Option(longName: "thresholds", Required = false, HelpText = "Threshold percentages for badge and health indicators, lower threshold can also be used to fail the action.", Default = "50 75")]
         public string Thresholds { get; set; }
+
+        [Option(longName: "verbosity", Required = false, HelpText = "Logging level - diagnostic or none", Default = "none")]
+        public string Verbosity { get; set; }
     }
 }

--- a/src/CodeCoverageSummary/Program.cs
+++ b/src/CodeCoverageSummary/Program.cs
@@ -28,6 +28,12 @@ namespace CodeCoverageSummary
 
                                          if (matchingFiles?.Any() == false)
                                          {
+                                             if (string.Equals(o.Verbosity, "diagnostic", StringComparison.OrdinalIgnoreCase))
+                                             {
+                                                Matcher matcher = new();
+                                                IEnumerable<string> matchingFiles = matcher.GetResultsInFullPath(".");
+                                                Console.WriteLine($"Files available in search path: {string.Join(Environment.NewLine, matchingFiles)}");
+                                             }
                                              Console.WriteLine("Error: No files found matching glob pattern.");
                                              return -2; // error
                                          }


### PR DESCRIPTION
for debugging "Error: No files found matching glob pattern."